### PR TITLE
Include timestamp in API requests

### DIFF
--- a/OmniRig_VB_DEMO/Form1.vb
+++ b/OmniRig_VB_DEMO/Form1.vb
@@ -141,12 +141,14 @@
                     Else
                         RadioName = "OmniRig 2"
                     End If
+                                
+                    Dim timestamp as String = DateTime.UtcNow.ToString("yyyy/MM/dd HH:mm:ss")
 
-                    Dim myString As String = "{""radio"": """ + RadioName + """, ""frequency"": """ + newfreq.ToString + """, ""mode"": """ + Label6.Text + """, ""key"": """ + My.Settings.CloudlogAPIKey + """}"
+                    Dim myString As String = "{""radio"": """ + RadioName + """, ""frequency"": """ + newfreq.ToString + """, ""mode"": """ + Label6.Text + """, ""timestamp"": """ + timestamp + """, ""key"": """ + My.Settings.CloudlogAPIKey + """}"
 
                     Try
                         Dim responsebytes = client.UploadString(My.Settings.CloudlogURL + "/index.php/api/radio", myString)
-                        ToolStripStatusLabel1.Text = "Cloudlog Synced: " + DateTime.UtcNow
+                        ToolStripStatusLabel1.Text = "Cloudlog Synced: " + timestamp
                     Catch ex As Exception
                         ToolStripStatusLabel1.Text = "Cloudlog Synced: Failed, check URL/API"
                     End Try


### PR DESCRIPTION
The backend expects a timestamp in the JSON otherwise it will raise `Column 'timestamp' cannot be null` errors.